### PR TITLE
Drop windows desktop SDK depedency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ I renamed it, but all the types are still in the original namespace so this shou
 
 More documentation would be appreciated via PRs, but this library is only for backward compatibility with .NET Framework applications being brought into .NET Core and .NET 5+, so it should not be used for new projects.
 
-The interactive service credential prompt is only available when targeting .NET Core 3.0+ since `System.Windows.Forms` is unavailable in .NET Standard 2.0. This functionality is untested (by me).
+The interactive service credential prompt is only available when targeting .NET Core 5.0-windows+ since `System.Windows.Forms` is unavailable in .NET Standard 2.0. This functionality is untested (by me).
 
 ---
 

--- a/System.ServiceProcess.Core.Tests/System.ServiceProcess.Core.Tests.csproj
+++ b/System.ServiceProcess.Core.Tests/System.ServiceProcess.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;net5.0-windows</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/System.ServiceProcess.Core/System.ServiceProcess.Core.csproj
+++ b/System.ServiceProcess.Core/System.ServiceProcess.Core.csproj
@@ -1,18 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>System.ServiceProcess.Core</AssemblyName>
     <AssemblyTitle>System.ServiceProcess</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0-windows</TargetFrameworks>
     <RootNamespace>System.ServiceProcess</RootNamespace>
-    <UseWindowsForms>true</UseWindowsForms>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1589</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net5.0'))">
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
   <PropertyGroup>
     <PackageId>Core.System.ServiceProcess</PackageId>
-    <Version>1.0.2</Version>
+    <Version>2.0.0</Version>
     <Description>Porting of System.ServiceProcess for .NET Standard 2.0 and .NET Core 3.0 from the Microsoft .NET Reference Source.</Description>
     <Product>Core.System.ServiceProcess</Product>
     <Copyright>Copyright (C) Microsoft Corporation (Modifications by Chris Benard)</Copyright>
@@ -29,7 +32,7 @@
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
   </ItemGroup>
-  
+
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <Compile Remove="Design\ServiceInstallerDialog.cs" />
     <Compile Remove="Design\ServiceNameConverter.cs" />


### PR DESCRIPTION
Adding package reference to `Core.System.ServiceProcess` when targeting .NET 5.0 (without windows forms) gives the following error:

> NETSDK1136	The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.

This PR drops the windows desktop SDK dependecy for `netstandard2.0` target framework, Updates the obsoleted `netcoreapp3.0` target framework with `net5.0-windows` and updates the package version to `2.0`.